### PR TITLE
add support for ultra-ms-logon-2 authentication

### DIFF
--- a/example/client/main.go
+++ b/example/client/main.go
@@ -35,8 +35,9 @@ func main() {
 	ccfg := &vnc.ClientConfig{
 		SecurityHandlers: []vnc.SecurityHandler{
 			//&vnc.ClientAuthATEN{Username: []byte(os.Args[2]), Password: []byte(os.Args[3])}
-			&vnc.ClientAuthVNC{Password: []byte("12345")},
-			&vnc.ClientAuthNone{},
+			// &vnc.ClientAuthVNC{Password: []byte("12345")},
+			// &vnc.ClientAuthNone{},
+			&vnc.ClientAuthUltraMsAutoLogon2{Username: []byte(os.Args[2]), Password: []byte(os.Args[3])},
 		},
 		DrawCursor:      true,
 		PixelFormat:     vnc.PixelFormat32bit,

--- a/example/client/ultra-ms-logon-2-encrypt/Makefile
+++ b/example/client/ultra-ms-logon-2-encrypt/Makefile
@@ -1,0 +1,27 @@
+all: vnc2video.zip
+
+ultra-ms-logon-2-encrypt: main.c d3des.h d3des.c
+	gcc -Os -o $@ -m64 main.c
+	strip $@
+
+vnc2video: ../main.go ffmpeg
+	(cd .. && go build -o $@)
+	cp ../$@ .
+
+vnc2video.zip: ultra-ms-logon-2-encrypt vnc2video ffmpeg
+	zip -9 $@ $^
+	sha256sum $@
+
+ffmpeg:
+	rm -rf ffmpeg-*-static*
+	wget -q https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz
+	tar xf ffmpeg-release-64bit-static.tar.xz
+	mv ffmpeg-*-static/ffmpeg .
+	chmod +x ffmpeg
+	rm -rf ffmpeg-*-static
+	./ffmpeg -version
+
+clean:
+	rm -f vnc2video.zip vnc2video ultra-ms-logon-2-encrypt ffmpeg-*-static* ffmpeg *.mov
+
+.PHONY: all clean

--- a/example/client/ultra-ms-logon-2-encrypt/README.md
+++ b/example/client/ultra-ms-logon-2-encrypt/README.md
@@ -1,0 +1,24 @@
+# About
+
+Encrypts a username and password as the ultra-vnc ms-auto-logon-2 plugin.
+
+# Usage
+
+Build:
+
+```bash
+make clean all
+```
+
+Then use it like:
+
+```bash
+./vnc2video example1.windows.com:5900 vagrant vagrant
+```
+
+## Source Code
+
+Most of the included source code came from:
+
+* https://github.com/TigerVNC/tigervnc/blob/8c6c584377feba0e3b99eecb3ef33b28cee318cb/common/rfb/d3des.h
+* https://github.com/TigerVNC/tigervnc/blob/8c6c584377feba0e3b99eecb3ef33b28cee318cb/common/rfb/d3des.c

--- a/example/client/ultra-ms-logon-2-encrypt/d3des.c
+++ b/example/client/ultra-ms-logon-2-encrypt/d3des.c
@@ -1,0 +1,434 @@
+/*
+ * This is D3DES (V5.09) by Richard Outerbridge with the double and
+ * triple-length support removed for use in VNC.  Also the bytebit[] array
+ * has been reversed so that the most significant bit in each byte of the
+ * key is ignored, not the least significant.
+ *
+ * These changes are:
+ *  Copyright (C) 1999 AT&T Laboratories Cambridge.  All Rights Reserved.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/* D3DES (V5.09) -
+ *
+ * A portable, public domain, version of the Data Encryption Standard.
+ *
+ * Written with Symantec's THINK (Lightspeed) C by Richard Outerbridge.
+ * Thanks to: Dan Hoey for his excellent Initial and Inverse permutation
+ * code;  Jim Gillogly & Phil Karn for the DES key schedule code; Dennis
+ * Ferguson, Eric Young and Dana How for comparing notes; and Ray Lau,
+ * for humouring me on.
+ *
+ * Copyright (c) 1988,1989,1990,1991,1992 by Richard Outerbridge.
+ * (GEnie : OUTER; CIS : [71755,204]) Graven Imagery, 1992.
+ */
+
+#include "d3des.h"
+
+static void scrunch(unsigned char *, unsigned long *);
+static void unscrun(unsigned long *, unsigned char *);
+static void desfunc(unsigned long *, unsigned long *);
+static void cookey(unsigned long *);
+
+static unsigned long KnL[32] = { 0L };
+
+static unsigned short bytebit[8]	= {
+	01, 02, 04, 010, 020, 040, 0100, 0200 };
+
+static unsigned long bigbyte[24] = {
+	0x800000L,	0x400000L,	0x200000L,	0x100000L,
+	0x80000L,	0x40000L,	0x20000L,	0x10000L,
+	0x8000L,	0x4000L,	0x2000L,	0x1000L,
+	0x800L, 	0x400L, 	0x200L, 	0x100L,
+	0x80L,		0x40L,		0x20L,		0x10L,
+	0x8L,		0x4L,		0x2L,		0x1L	};
+
+/* Use the key schedule specified in the Standard (ANSI X3.92-1981). */
+
+static unsigned char pc1[56] = {
+	56, 48, 40, 32, 24, 16,  8,	 0, 57, 49, 41, 33, 25, 17,
+	 9,  1, 58, 50, 42, 34, 26,	18, 10,  2, 59, 51, 43, 35,
+	62, 54, 46, 38, 30, 22, 14,	 6, 61, 53, 45, 37, 29, 21,
+	13,  5, 60, 52, 44, 36, 28,	20, 12,  4, 27, 19, 11,  3 };
+
+static unsigned char totrot[16] = {
+	1,2,4,6,8,10,12,14,15,17,19,21,23,25,27,28 };
+
+static unsigned char pc2[48] = {
+	13, 16, 10, 23,  0,  4,  2, 27, 14,  5, 20,  9,
+	22, 18, 11,  3, 25,  7, 15,  6, 26, 19, 12,  1,
+	40, 51, 30, 36, 46, 54, 29, 39, 50, 44, 32, 47,
+	43, 48, 38, 55, 33, 52, 45, 41, 49, 35, 28, 31 };
+
+void deskey(key, edf)	/* Thanks to James Gillogly & Phil Karn! */
+unsigned char *key;
+int edf;
+{
+	register int i, j, l, m, n;
+	unsigned char pc1m[56], pcr[56];
+	unsigned long kn[32];
+
+	for ( j = 0; j < 56; j++ ) {
+		l = pc1[j];
+		m = l & 07;
+		pc1m[j] = (key[l >> 3] & bytebit[m]) ? 1 : 0;
+		}
+	for( i = 0; i < 16; i++ ) {
+		if( edf == DE1 ) m = (15 - i) << 1;
+		else m = i << 1;
+		n = m + 1;
+		kn[m] = kn[n] = 0L;
+		for( j = 0; j < 28; j++ ) {
+			l = j + totrot[i];
+			if( l < 28 ) pcr[j] = pc1m[l];
+			else pcr[j] = pc1m[l - 28];
+			}
+		for( j = 28; j < 56; j++ ) {
+		    l = j + totrot[i];
+		    if( l < 56 ) pcr[j] = pc1m[l];
+		    else pcr[j] = pc1m[l - 28];
+		    }
+		for( j = 0; j < 24; j++ ) {
+			if( pcr[pc2[j]] ) kn[m] |= bigbyte[j];
+			if( pcr[pc2[j+24]] ) kn[n] |= bigbyte[j];
+			}
+		}
+	cookey(kn);
+	return;
+	}
+
+static void cookey(raw1)
+register unsigned long *raw1;
+{
+	register unsigned long *cook, *raw0;
+	unsigned long dough[32];
+	register int i;
+
+	cook = dough;
+	for( i = 0; i < 16; i++, raw1++ ) {
+		raw0 = raw1++;
+		*cook	 = (*raw0 & 0x00fc0000L) << 6;
+		*cook	|= (*raw0 & 0x00000fc0L) << 10;
+		*cook	|= (*raw1 & 0x00fc0000L) >> 10;
+		*cook++ |= (*raw1 & 0x00000fc0L) >> 6;
+		*cook	 = (*raw0 & 0x0003f000L) << 12;
+		*cook	|= (*raw0 & 0x0000003fL) << 16;
+		*cook	|= (*raw1 & 0x0003f000L) >> 4;
+		*cook++ |= (*raw1 & 0x0000003fL);
+		}
+	usekey(dough);
+	return;
+	}
+
+void cpkey(into)
+register unsigned long *into;
+{
+	register unsigned long *from, *endp;
+
+	from = KnL, endp = &KnL[32];
+	while( from < endp ) *into++ = *from++;
+	return;
+	}
+
+void usekey(from)
+register unsigned long *from;
+{
+	register unsigned long *to, *endp;
+
+	to = KnL, endp = &KnL[32];
+	while( to < endp ) *to++ = *from++;
+	return;
+	}
+
+void des(inblock, outblock)
+unsigned char *inblock, *outblock;
+{
+	unsigned long work[2];
+
+	scrunch(inblock, work);
+	desfunc(work, KnL);
+	unscrun(work, outblock);
+	return;
+	}
+
+static void scrunch(outof, into)
+register unsigned char *outof;
+register unsigned long *into;
+{
+	*into	 = (*outof++ & 0xffL) << 24;
+	*into	|= (*outof++ & 0xffL) << 16;
+	*into	|= (*outof++ & 0xffL) << 8;
+	*into++ |= (*outof++ & 0xffL);
+	*into	 = (*outof++ & 0xffL) << 24;
+	*into	|= (*outof++ & 0xffL) << 16;
+	*into	|= (*outof++ & 0xffL) << 8;
+	*into	|= (*outof   & 0xffL);
+	return;
+	}
+
+static void unscrun(outof, into)
+register unsigned long *outof;
+register unsigned char *into;
+{
+	*into++ = (unsigned char)((*outof >> 24) & 0xffL);
+	*into++ = (unsigned char)((*outof >> 16) & 0xffL);
+	*into++ = (unsigned char)((*outof >>  8) & 0xffL);
+	*into++ = (unsigned char)(*outof++	 & 0xffL);
+	*into++ = (unsigned char)((*outof >> 24) & 0xffL);
+	*into++ = (unsigned char)((*outof >> 16) & 0xffL);
+	*into++ = (unsigned char)((*outof >>  8) & 0xffL);
+	*into	=  (unsigned char)(*outof	 & 0xffL);
+	return;
+	}
+
+static unsigned long SP1[64] = {
+	0x01010400L, 0x00000000L, 0x00010000L, 0x01010404L,
+	0x01010004L, 0x00010404L, 0x00000004L, 0x00010000L,
+	0x00000400L, 0x01010400L, 0x01010404L, 0x00000400L,
+	0x01000404L, 0x01010004L, 0x01000000L, 0x00000004L,
+	0x00000404L, 0x01000400L, 0x01000400L, 0x00010400L,
+	0x00010400L, 0x01010000L, 0x01010000L, 0x01000404L,
+	0x00010004L, 0x01000004L, 0x01000004L, 0x00010004L,
+	0x00000000L, 0x00000404L, 0x00010404L, 0x01000000L,
+	0x00010000L, 0x01010404L, 0x00000004L, 0x01010000L,
+	0x01010400L, 0x01000000L, 0x01000000L, 0x00000400L,
+	0x01010004L, 0x00010000L, 0x00010400L, 0x01000004L,
+	0x00000400L, 0x00000004L, 0x01000404L, 0x00010404L,
+	0x01010404L, 0x00010004L, 0x01010000L, 0x01000404L,
+	0x01000004L, 0x00000404L, 0x00010404L, 0x01010400L,
+	0x00000404L, 0x01000400L, 0x01000400L, 0x00000000L,
+	0x00010004L, 0x00010400L, 0x00000000L, 0x01010004L };
+
+static unsigned long SP2[64] = {
+	0x80108020L, 0x80008000L, 0x00008000L, 0x00108020L,
+	0x00100000L, 0x00000020L, 0x80100020L, 0x80008020L,
+	0x80000020L, 0x80108020L, 0x80108000L, 0x80000000L,
+	0x80008000L, 0x00100000L, 0x00000020L, 0x80100020L,
+	0x00108000L, 0x00100020L, 0x80008020L, 0x00000000L,
+	0x80000000L, 0x00008000L, 0x00108020L, 0x80100000L,
+	0x00100020L, 0x80000020L, 0x00000000L, 0x00108000L,
+	0x00008020L, 0x80108000L, 0x80100000L, 0x00008020L,
+	0x00000000L, 0x00108020L, 0x80100020L, 0x00100000L,
+	0x80008020L, 0x80100000L, 0x80108000L, 0x00008000L,
+	0x80100000L, 0x80008000L, 0x00000020L, 0x80108020L,
+	0x00108020L, 0x00000020L, 0x00008000L, 0x80000000L,
+	0x00008020L, 0x80108000L, 0x00100000L, 0x80000020L,
+	0x00100020L, 0x80008020L, 0x80000020L, 0x00100020L,
+	0x00108000L, 0x00000000L, 0x80008000L, 0x00008020L,
+	0x80000000L, 0x80100020L, 0x80108020L, 0x00108000L };
+
+static unsigned long SP3[64] = {
+	0x00000208L, 0x08020200L, 0x00000000L, 0x08020008L,
+	0x08000200L, 0x00000000L, 0x00020208L, 0x08000200L,
+	0x00020008L, 0x08000008L, 0x08000008L, 0x00020000L,
+	0x08020208L, 0x00020008L, 0x08020000L, 0x00000208L,
+	0x08000000L, 0x00000008L, 0x08020200L, 0x00000200L,
+	0x00020200L, 0x08020000L, 0x08020008L, 0x00020208L,
+	0x08000208L, 0x00020200L, 0x00020000L, 0x08000208L,
+	0x00000008L, 0x08020208L, 0x00000200L, 0x08000000L,
+	0x08020200L, 0x08000000L, 0x00020008L, 0x00000208L,
+	0x00020000L, 0x08020200L, 0x08000200L, 0x00000000L,
+	0x00000200L, 0x00020008L, 0x08020208L, 0x08000200L,
+	0x08000008L, 0x00000200L, 0x00000000L, 0x08020008L,
+	0x08000208L, 0x00020000L, 0x08000000L, 0x08020208L,
+	0x00000008L, 0x00020208L, 0x00020200L, 0x08000008L,
+	0x08020000L, 0x08000208L, 0x00000208L, 0x08020000L,
+	0x00020208L, 0x00000008L, 0x08020008L, 0x00020200L };
+
+static unsigned long SP4[64] = {
+	0x00802001L, 0x00002081L, 0x00002081L, 0x00000080L,
+	0x00802080L, 0x00800081L, 0x00800001L, 0x00002001L,
+	0x00000000L, 0x00802000L, 0x00802000L, 0x00802081L,
+	0x00000081L, 0x00000000L, 0x00800080L, 0x00800001L,
+	0x00000001L, 0x00002000L, 0x00800000L, 0x00802001L,
+	0x00000080L, 0x00800000L, 0x00002001L, 0x00002080L,
+	0x00800081L, 0x00000001L, 0x00002080L, 0x00800080L,
+	0x00002000L, 0x00802080L, 0x00802081L, 0x00000081L,
+	0x00800080L, 0x00800001L, 0x00802000L, 0x00802081L,
+	0x00000081L, 0x00000000L, 0x00000000L, 0x00802000L,
+	0x00002080L, 0x00800080L, 0x00800081L, 0x00000001L,
+	0x00802001L, 0x00002081L, 0x00002081L, 0x00000080L,
+	0x00802081L, 0x00000081L, 0x00000001L, 0x00002000L,
+	0x00800001L, 0x00002001L, 0x00802080L, 0x00800081L,
+	0x00002001L, 0x00002080L, 0x00800000L, 0x00802001L,
+	0x00000080L, 0x00800000L, 0x00002000L, 0x00802080L };
+
+static unsigned long SP5[64] = {
+	0x00000100L, 0x02080100L, 0x02080000L, 0x42000100L,
+	0x00080000L, 0x00000100L, 0x40000000L, 0x02080000L,
+	0x40080100L, 0x00080000L, 0x02000100L, 0x40080100L,
+	0x42000100L, 0x42080000L, 0x00080100L, 0x40000000L,
+	0x02000000L, 0x40080000L, 0x40080000L, 0x00000000L,
+	0x40000100L, 0x42080100L, 0x42080100L, 0x02000100L,
+	0x42080000L, 0x40000100L, 0x00000000L, 0x42000000L,
+	0x02080100L, 0x02000000L, 0x42000000L, 0x00080100L,
+	0x00080000L, 0x42000100L, 0x00000100L, 0x02000000L,
+	0x40000000L, 0x02080000L, 0x42000100L, 0x40080100L,
+	0x02000100L, 0x40000000L, 0x42080000L, 0x02080100L,
+	0x40080100L, 0x00000100L, 0x02000000L, 0x42080000L,
+	0x42080100L, 0x00080100L, 0x42000000L, 0x42080100L,
+	0x02080000L, 0x00000000L, 0x40080000L, 0x42000000L,
+	0x00080100L, 0x02000100L, 0x40000100L, 0x00080000L,
+	0x00000000L, 0x40080000L, 0x02080100L, 0x40000100L };
+
+static unsigned long SP6[64] = {
+	0x20000010L, 0x20400000L, 0x00004000L, 0x20404010L,
+	0x20400000L, 0x00000010L, 0x20404010L, 0x00400000L,
+	0x20004000L, 0x00404010L, 0x00400000L, 0x20000010L,
+	0x00400010L, 0x20004000L, 0x20000000L, 0x00004010L,
+	0x00000000L, 0x00400010L, 0x20004010L, 0x00004000L,
+	0x00404000L, 0x20004010L, 0x00000010L, 0x20400010L,
+	0x20400010L, 0x00000000L, 0x00404010L, 0x20404000L,
+	0x00004010L, 0x00404000L, 0x20404000L, 0x20000000L,
+	0x20004000L, 0x00000010L, 0x20400010L, 0x00404000L,
+	0x20404010L, 0x00400000L, 0x00004010L, 0x20000010L,
+	0x00400000L, 0x20004000L, 0x20000000L, 0x00004010L,
+	0x20000010L, 0x20404010L, 0x00404000L, 0x20400000L,
+	0x00404010L, 0x20404000L, 0x00000000L, 0x20400010L,
+	0x00000010L, 0x00004000L, 0x20400000L, 0x00404010L,
+	0x00004000L, 0x00400010L, 0x20004010L, 0x00000000L,
+	0x20404000L, 0x20000000L, 0x00400010L, 0x20004010L };
+
+static unsigned long SP7[64] = {
+	0x00200000L, 0x04200002L, 0x04000802L, 0x00000000L,
+	0x00000800L, 0x04000802L, 0x00200802L, 0x04200800L,
+	0x04200802L, 0x00200000L, 0x00000000L, 0x04000002L,
+	0x00000002L, 0x04000000L, 0x04200002L, 0x00000802L,
+	0x04000800L, 0x00200802L, 0x00200002L, 0x04000800L,
+	0x04000002L, 0x04200000L, 0x04200800L, 0x00200002L,
+	0x04200000L, 0x00000800L, 0x00000802L, 0x04200802L,
+	0x00200800L, 0x00000002L, 0x04000000L, 0x00200800L,
+	0x04000000L, 0x00200800L, 0x00200000L, 0x04000802L,
+	0x04000802L, 0x04200002L, 0x04200002L, 0x00000002L,
+	0x00200002L, 0x04000000L, 0x04000800L, 0x00200000L,
+	0x04200800L, 0x00000802L, 0x00200802L, 0x04200800L,
+	0x00000802L, 0x04000002L, 0x04200802L, 0x04200000L,
+	0x00200800L, 0x00000000L, 0x00000002L, 0x04200802L,
+	0x00000000L, 0x00200802L, 0x04200000L, 0x00000800L,
+	0x04000002L, 0x04000800L, 0x00000800L, 0x00200002L };
+
+static unsigned long SP8[64] = {
+	0x10001040L, 0x00001000L, 0x00040000L, 0x10041040L,
+	0x10000000L, 0x10001040L, 0x00000040L, 0x10000000L,
+	0x00040040L, 0x10040000L, 0x10041040L, 0x00041000L,
+	0x10041000L, 0x00041040L, 0x00001000L, 0x00000040L,
+	0x10040000L, 0x10000040L, 0x10001000L, 0x00001040L,
+	0x00041000L, 0x00040040L, 0x10040040L, 0x10041000L,
+	0x00001040L, 0x00000000L, 0x00000000L, 0x10040040L,
+	0x10000040L, 0x10001000L, 0x00041040L, 0x00040000L,
+	0x00041040L, 0x00040000L, 0x10041000L, 0x00001000L,
+	0x00000040L, 0x10040040L, 0x00001000L, 0x00041040L,
+	0x10001000L, 0x00000040L, 0x10000040L, 0x10040000L,
+	0x10040040L, 0x10000000L, 0x00040000L, 0x10001040L,
+	0x00000000L, 0x10041040L, 0x00040040L, 0x10000040L,
+	0x10040000L, 0x10001000L, 0x10001040L, 0x00000000L,
+	0x10041040L, 0x00041000L, 0x00041000L, 0x00001040L,
+	0x00001040L, 0x00040040L, 0x10000000L, 0x10041000L };
+
+static void desfunc(block, keys)
+register unsigned long *block, *keys;
+{
+	register unsigned long fval, work, right, leftt;
+	register int round;
+
+	leftt = block[0];
+	right = block[1];
+	work = ((leftt >> 4) ^ right) & 0x0f0f0f0fL;
+	right ^= work;
+	leftt ^= (work << 4);
+	work = ((leftt >> 16) ^ right) & 0x0000ffffL;
+	right ^= work;
+	leftt ^= (work << 16);
+	work = ((right >> 2) ^ leftt) & 0x33333333L;
+	leftt ^= work;
+	right ^= (work << 2);
+	work = ((right >> 8) ^ leftt) & 0x00ff00ffL;
+	leftt ^= work;
+	right ^= (work << 8);
+	right = ((right << 1) | ((right >> 31) & 1L)) & 0xffffffffL;
+	work = (leftt ^ right) & 0xaaaaaaaaL;
+	leftt ^= work;
+	right ^= work;
+	leftt = ((leftt << 1) | ((leftt >> 31) & 1L)) & 0xffffffffL;
+
+	for( round = 0; round < 8; round++ ) {
+		work  = (right << 28) | (right >> 4);
+		work ^= *keys++;
+		fval  = SP7[ work		 & 0x3fL];
+		fval |= SP5[(work >>  8) & 0x3fL];
+		fval |= SP3[(work >> 16) & 0x3fL];
+		fval |= SP1[(work >> 24) & 0x3fL];
+		work  = right ^ *keys++;
+		fval |= SP8[ work		 & 0x3fL];
+		fval |= SP6[(work >>  8) & 0x3fL];
+		fval |= SP4[(work >> 16) & 0x3fL];
+		fval |= SP2[(work >> 24) & 0x3fL];
+		leftt ^= fval;
+		work  = (leftt << 28) | (leftt >> 4);
+		work ^= *keys++;
+		fval  = SP7[ work		 & 0x3fL];
+		fval |= SP5[(work >>  8) & 0x3fL];
+		fval |= SP3[(work >> 16) & 0x3fL];
+		fval |= SP1[(work >> 24) & 0x3fL];
+		work  = leftt ^ *keys++;
+		fval |= SP8[ work		 & 0x3fL];
+		fval |= SP6[(work >>  8) & 0x3fL];
+		fval |= SP4[(work >> 16) & 0x3fL];
+		fval |= SP2[(work >> 24) & 0x3fL];
+		right ^= fval;
+		}
+
+	right = (right << 31) | (right >> 1);
+	work = (leftt ^ right) & 0xaaaaaaaaL;
+	leftt ^= work;
+	right ^= work;
+	leftt = (leftt << 31) | (leftt >> 1);
+	work = ((leftt >> 8) ^ right) & 0x00ff00ffL;
+	right ^= work;
+	leftt ^= (work << 8);
+	work = ((leftt >> 2) ^ right) & 0x33333333L;
+	right ^= work;
+	leftt ^= (work << 2);
+	work = ((right >> 16) ^ leftt) & 0x0000ffffL;
+	leftt ^= work;
+	right ^= (work << 16);
+	work = ((right >> 4) ^ leftt) & 0x0f0f0f0fL;
+	leftt ^= work;
+	right ^= (work << 4);
+	*block++ = right;
+	*block = leftt;
+	return;
+	}
+
+/* Validation sets:
+ *
+ * Single-length key, single-length plaintext -
+ * Key	  : 0123 4567 89ab cdef
+ * Plain  : 0123 4567 89ab cde7
+ * Cipher : c957 4425 6a5e d31d
+ *
+ * Double-length key, single-length plaintext -
+ * Key	  : 0123 4567 89ab cdef fedc ba98 7654 3210
+ * Plain  : 0123 4567 89ab cde7
+ * Cipher : 7f1d 0a77 826b 8aff
+ *
+ * Double-length key, double-length plaintext -
+ * Key	  : 0123 4567 89ab cdef fedc ba98 7654 3210
+ * Plain  : 0123 4567 89ab cdef 0123 4567 89ab cdff
+ * Cipher : 27a0 8440 406a df60 278f 47cf 42d6 15d7
+ *
+ * Triple-length key, single-length plaintext -
+ * Key	  : 0123 4567 89ab cdef fedc ba98 7654 3210 89ab cdef 0123 4567
+ * Plain  : 0123 4567 89ab cde7
+ * Cipher : de0b 7c06 ae5e 0ed5
+ *
+ * Triple-length key, double-length plaintext -
+ * Key	  : 0123 4567 89ab cdef fedc ba98 7654 3210 89ab cdef 0123 4567
+ * Plain  : 0123 4567 89ab cdef 0123 4567 89ab cdff
+ * Cipher : ad0d 1b30 ac17 cf07 0ed1 1c63 81e4 4de5
+ *
+ * d3des V5.0a rwo 9208.07 18:44 Graven Imagery
+ **********************************************************************/

--- a/example/client/ultra-ms-logon-2-encrypt/d3des.h
+++ b/example/client/ultra-ms-logon-2-encrypt/d3des.h
@@ -1,0 +1,59 @@
+/*
+ * This is D3DES (V5.09) by Richard Outerbridge with the double and
+ * triple-length support removed for use in VNC.
+ *
+ * These changes are:
+ *  Copyright (C) 1999 AT&T Laboratories Cambridge.  All Rights Reserved.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/* d3des.h -
+ *
+ *	Headers and defines for d3des.c
+ *	Graven Imagery, 1992.
+ *
+ * Copyright (c) 1988,1989,1990,1991,1992 by Richard Outerbridge
+ *	(GEnie : OUTER; CIS : [71755,204])
+ */
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+#define EN0	0	/* MODE == encrypt */
+#define DE1	1	/* MODE == decrypt */
+
+extern void deskey(unsigned char *, int);
+/*		      hexkey[8]     MODE
+ * Sets the internal key register according to the hexadecimal
+ * key contained in the 8 bytes of hexkey, according to the DES,
+ * for encryption or decryption according to MODE.
+ */
+
+extern void usekey(unsigned long *);
+/*		    cookedkey[32]
+ * Loads the internal key register with the data in cookedkey.
+ */
+
+extern void cpkey(unsigned long *);
+/*		   cookedkey[32]
+ * Copies the contents of the internal key register into the storage
+ * located at &cookedkey[0].
+ */
+
+extern void des(unsigned char *, unsigned char *);
+/*		    from[8]	      to[8]
+ * Encrypts/Decrypts (according to the key currently loaded in the
+ * internal key register) one block of eight bytes at address 'from'
+ * into the block at address 'to'.  They can be the same.
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+/* d3des.h V5.09 rwo 9208.04 15:06 Graven Imagery
+ ********************************************************************/

--- a/example/client/ultra-ms-logon-2-encrypt/main.c
+++ b/example/client/ultra-ms-logon-2-encrypt/main.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "d3des.h"
+#include "d3des.c"
+
+static void vncEncryptBytes2(unsigned char *where, const int length, unsigned char *key) {
+	int i, j;
+	deskey(key, EN0);
+	for (i = 0; i< 8; i++)
+		where[i] ^= key[i];
+	des(where, where);
+	for (i = 8; i < length; i += 8) {
+		for (j = 0; j < 8; j++)
+			where[i + j] ^= where[i + j - 8];
+		des(where + i, where + i);
+	}
+}
+
+static void encrypt(unsigned char *key, int cipherTextSize, unsigned char *plainText) {
+    unsigned char cipherText[cipherTextSize];
+    memset(cipherText, 0, sizeof(cipherText));
+    strcpy(cipherText, plainText);
+
+    vncEncryptBytes2(cipherText, sizeof(cipherText), key);
+    for (int i = 0; i < sizeof(cipherText); ++i) {
+        printf("%02x", cipherText[i]);
+    }
+    printf("\n");
+}
+
+// usage:   ./ultra-ms-logon-2-encrypt des-key-hex cipher-text-size plain-text
+// example: ./ultra-ms-logon-2-encrypt 3c89f4466dc2a67a 256 vagrant
+int main(int argc, char **argv) {
+    if (argc != 4) {
+        return 1;
+    }
+
+    char *keyHex = argv[1];
+    if (16 != strlen(keyHex)) {
+        return 2;
+    }
+    unsigned char key[8];
+    for (int i = 0; i < 8; ++i) {
+        sscanf(keyHex, "%2hhx", &key[i]);
+        keyHex += 2;
+    }
+
+    encrypt(key, atoi(argv[2]), argv[3]);
+
+    return 0;
+}

--- a/security.go
+++ b/security.go
@@ -5,12 +5,13 @@ type SecurityType uint8
 //go:generate stringer -type=SecurityType
 
 const (
-	SecTypeUnknown  SecurityType = SecurityType(0)
-	SecTypeNone     SecurityType = SecurityType(1)
-	SecTypeVNC      SecurityType = SecurityType(2)
-	SecTypeTight    SecurityType = SecurityType(16)
-	SecTypeATEN     SecurityType = SecurityType(16)
-	SecTypeVeNCrypt SecurityType = SecurityType(19)
+	SecTypeUnknown           SecurityType = SecurityType(0)
+	SecTypeNone              SecurityType = SecurityType(1)
+	SecTypeVNC               SecurityType = SecurityType(2)
+	SecTypeTight             SecurityType = SecurityType(16)
+	SecTypeATEN              SecurityType = SecurityType(16)
+	SecTypeVeNCrypt          SecurityType = SecurityType(19)
+	SecTypeUltraMsAutoLogon2 SecurityType = SecurityType(113)
 )
 
 type SecuritySubType uint32

--- a/security_ultra_ms_auto_logon_2.go
+++ b/security_ultra_ms_auto_logon_2.go
@@ -1,0 +1,175 @@
+package vnc2video
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/monnand/dhkx"
+)
+
+// ClientAuthUltraMsAutoLogon2 is implemented by Ultra VNC when using the MS-Logon II authentication.
+// see http://www.uvnc.com/features/authentication.html
+type ClientAuthUltraMsAutoLogon2 struct {
+	Username []byte
+	Password []byte
+}
+
+func (*ClientAuthUltraMsAutoLogon2) Type() SecurityType {
+	return SecTypeUltraMsAutoLogon2
+}
+
+func (*ClientAuthUltraMsAutoLogon2) SubType() SecuritySubType {
+	return SecSubTypeUnknown
+}
+
+func (auth *ClientAuthUltraMsAutoLogon2) Auth(c Conn) error {
+	if len(auth.Username) == 0 {
+		return fmt.Errorf("security handshake failed; no username provided for UltraMsAutoLogon2Auth")
+	}
+	if len(auth.Password) == 0 {
+		return fmt.Errorf("security handshake failed; no password provided for UltraMsAutoLogon2Auth")
+	}
+
+	fmt.Printf("calling binary.Read generator...\n")
+
+	var generator int64
+	if err := binary.Read(c, binary.BigEndian, &generator); err != nil {
+		return err
+	}
+
+	fmt.Printf("calling binary.Read prime...\n")
+
+	var prime int64
+	if err := binary.Read(c, binary.BigEndian, &prime); err != nil {
+		return err
+	}
+
+	fmt.Printf("calling binary.Read public server key...\n")
+
+	var a [8]byte
+	if err := binary.Read(c, binary.BigEndian, &a); err != nil {
+		return err
+	}
+
+	fmt.Printf("calling authUltraMsAutoLogon2Encode...\n")
+
+	b, encryptedUsername, encryptedPassword, err := authUltraMsAutoLogon2Encode(auth.Username, auth.Password, generator, prime, a[:])
+	if err != nil {
+		return err
+	}
+
+	if err := binary.Write(c, binary.BigEndian, b); err != nil {
+		return err
+	}
+	if err := binary.Write(c, binary.BigEndian, encryptedUsername); err != nil {
+		return err
+	}
+	if err := binary.Write(c, binary.BigEndian, encryptedPassword); err != nil {
+		return err
+	}
+
+	fmt.Printf("flushing...\n")
+
+	return c.Flush()
+}
+
+func authUltraMsAutoLogon2Encode(username []byte, password []byte, generator int64, prime int64, a []byte) (b []byte, encryptedUsername []byte, encryptedPassword []byte, err error) {
+	if len(a) != 8 {
+		return nil, nil, nil, fmt.Errorf("server public key size not 8 byte long")
+	}
+
+	group := dhkx.CreateGroup(big.NewInt(prime), big.NewInt(generator))
+
+	clientPrivateKey, err := group.GeneratePrivateKey(nil)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	b = make([]byte, 8)
+	copyWithLeftPad(b, clientPrivateKey.Bytes()) // b is the client public key.
+
+	serverPublicKey := dhkx.NewPublicKey(a)
+
+	key, err := group.ComputeKey(serverPublicKey, clientPrivateKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	s := make([]byte, 8)
+	copyWithLeftPad(s, key.Bytes())
+
+	// dump a log line exactly as the ultravnc server shows in its winvnc.log file.
+	i := int64(binary.BigEndian.Uint64(a))
+	k := int64(binary.BigEndian.Uint64(s))
+	fmt.Printf("After DH: g=%d m=%d i=%d key=%d\n", generator, prime, i, k)
+
+	// // Each byte of the password needs to be reversed. This is a
+	// // non RFC-documented behaviour of VNC clients and servers
+	// for i := range s {
+	// 	s[i] = (s[i]&0x55)<<1 | (s[i]&0xAA)>>1 // Swap adjacent bits
+	// 	s[i] = (s[i]&0x33)<<2 | (s[i]&0xCC)>>2 // Swap adjacent pairs
+	// 	s[i] = (s[i]&0x0F)<<4 | (s[i]&0xF0)>>4 // Swap the 2 halves
+	// }
+
+	fmt.Printf("username=%s\n", username)
+	fmt.Printf("password=%s\n", password)
+
+	encryptedUsername, err = encrypt(256, username, s)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	encryptedPassword, err = encrypt(64, password, s)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	fmt.Printf("encryptedUsername=%s\n", hex.EncodeToString(encryptedUsername))
+	fmt.Printf("encryptedPassword=%s\n", hex.EncodeToString(encryptedPassword))
+	fmt.Printf("key=%s\n", hex.EncodeToString(s))
+
+	return
+}
+
+func encrypt(cipherTextLength int, plainText []byte, key []byte) ([]byte, error) {
+	out, err := exec.Command(
+		"./ultra-ms-logon-2-encrypt",
+		hex.EncodeToString(key),
+		strconv.Itoa(cipherTextLength),
+		string(plainText)).Output()
+	if err != nil {
+		return nil, err
+	}
+	return hex.DecodeString(strings.TrimSpace(string(out)))
+
+	// XXX so the following code should have worked... but the vnc des
+	//     implementation does not seem to be standard... so I had to
+	//	   create an external application that uses the same C code as
+	//     TightVNC/UltraVNC and that works... any idea why?
+	// // create zero-padded slice.
+	// cipherText := make([]byte, cipherTextLength)
+	// copy(cipherText, plainText)
+
+	// block, err := des.NewCipher(key)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// mode := cipher.NewCBCEncrypter(block, key)
+	// mode.CryptBlocks(cipherText, cipherText)
+
+	// return cipherText, nil
+}
+
+func copyWithLeftPad(dest, src []byte) {
+	numPaddingBytes := len(dest) - len(src)
+	for i := 0; i < numPaddingBytes; i++ {
+		dest[i] = 0
+	}
+	copy(dest[numPaddingBytes:], src)
+}


### PR DESCRIPTION
this will add support for the ultra-ms-logon-2 authentication used in ultravnc, but right now its really a plea for your help! :-)

the code is still pretty much in PoC mode (but works) until we figure out why the Go DES implementation does not generate the same cipher-text as the code in ultravnc/tightvnc.

to make it work I had to take a detour and use the actual code from vnc... BUT I'm scratching my head on why the normal DES implementation (from Go) does not work. Do you known why?

The [code that should have worked](https://github.com/rgl/vnc2video/commit/06bfc06929d47aee1cabcc497f2053784fff072c#diff-55103b8d471ccd5af796f97a27033629R150) is commented:

```go
func encrypt(cipherTextLength int, plainText []byte, key []byte) ([]byte, error) {
	out, err := exec.Command(
		"./ultra-ms-logon-2-encrypt",
		hex.EncodeToString(key),
		strconv.Itoa(cipherTextLength),
		string(plainText)).Output()
	if err != nil {
		return nil, err
	}
	return hex.DecodeString(strings.TrimSpace(string(out)))

	// XXX so the following code should have worked... but the vnc des
	//     implementation does not seem to be standard... so I had to
	//	   create an external application that uses the same C code as
	//     TightVNC/UltraVNC and that works... any idea why?
	// // create zero-padded slice.
	// cipherText := make([]byte, cipherTextLength)
	// copy(cipherText, plainText)

	// block, err := des.NewCipher(key)
	// if err != nil {
	// 	return nil, err
	// }

	// mode := cipher.NewCBCEncrypter(block, key)
	// mode.CryptBlocks(cipherText, cipherText)

	// return cipherText, nil
}
```

once this is cleared up I think we have enough to write this down on @rfbproto and implement it in vnc2video and noVNC.

can you also have a look at https://github.com/novnc/noVNC/issues/1197? There, I'm also trying to document the ultra-ms-logon-2 authentication and implement it in noVNC.