### PR TITLE
Update encoding_util.go

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,9 +43,6 @@ func Connect(ctx context.Context, c net.Conn, cfg *ClientConfig) (*ClientConn, e
 		}
 	}
 
-	canvas := NewVncCanvas(int(conn.Width()), int(conn.Height()))
-	canvas.DrawCursor = cfg.DrawCursor
-	conn.Canvas = canvas
 	return conn, nil
 }
 

--- a/encoding_util.go
+++ b/encoding_util.go
@@ -58,7 +58,7 @@ func (c *VncCanvas) Reset(rect *Rectangle) {
 }
 
 func (c *VncCanvas) RemoveCursor() image.Image {
-	if c.Cursor == nil || c.CursorLocation == nil {
+	if c == nil || c.Cursor == nil || c.CursorLocation == nil {
 		return c.Image
 	}
 	if !c.DrawCursor {

--- a/encoding_util.go
+++ b/encoding_util.go
@@ -58,7 +58,7 @@ func (c *VncCanvas) Reset(rect *Rectangle) {
 }
 
 func (c *VncCanvas) RemoveCursor() image.Image {
-	if c == nil || c.Cursor == nil || c.CursorLocation == nil {
+	if c.Cursor == nil || c.CursorLocation == nil {
 		return c.Image
 	}
 	if !c.DrawCursor {

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -84,15 +84,6 @@ func main() {
 	//go vcodec.Run("C:\\Users\\betzalel\\Dropbox\\go\\src\\vnc2video\\example\\client\\ffmpeg.exe", "output.mp4")
 	//vcodec.Run("./output")
 
-	//screenImage := vnc.NewVncCanvas(int(cc.Width()), int(cc.Height()))
-
-	for _, enc := range ccfg.Encodings {
-		myRenderer, ok := enc.(vnc.Renderer)
-
-		if ok {
-			myRenderer.SetTargetImage(screenImage)
-		}
-	}
 	// var out *os.File
 
 	logger.Tracef("connected to: %s", os.Args[1])

--- a/handlers.go
+++ b/handlers.go
@@ -345,6 +345,21 @@ func (*DefaultClientServerInitHandler) Handle(c Conn) error {
 		//		return err
 		//	}
 	}*/
+
+	// set up canvas and init renderer before other
+	cfg := c.Config().(*ClientConfig)
+	canvas := NewVncCanvas(int(c.Width()), int(c.Height()))
+	canvas.DrawCursor = cfg.DrawCursor
+	c.(*ClientConn).Canvas = canvas
+
+	for _, enc := range cfg.Encodings {
+		myRenderer, ok := enc.(Renderer)
+
+		if ok {
+			myRenderer.SetTargetImage(canvas)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
fix this panic
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x96df96]

goroutine 60 [running]:
github.com/amitbet/vnc2video.(*VncCanvas).RemoveCursor(0x0, 0xc000139b00, 0xc0003faedf)
        D:/go1.13.8.windows-amd64/gopath/pkg/mod/github.com/amitbet/vnc2video@v0.0.0-20190616012314-9d50b9dab1d9/encoding_util.go:61 +0x26
github.com/amitbet/vnc2video.(*DefaultClientMessageHandler).Handle.func2(0xc0003434d0, 0xbce180, 0xc000120a00, 0xc0002e8b20, 0xc00011e500, 0xc000139b00)
        D:/go1.13.8.windows-amd64/gopath/pkg/mod/github.com/amitbet/vnc2video@v0.0.0-20190616012314-9d50b9dab1d9/client.go:303 +0x2ab
created by github.com/amitbet/vnc2video.(*DefaultClientMessageHandler).Handle
        D:/go1.13.8.windows-amd64/gopath/pkg/mod/github.com/amitbet/vnc2video@v0.0.0-20190616012314-9d50b9dab1d9/client.go:285 +0x2b8
```