### PR TITLE
Move Canvas and Renderer initialization to DefaultClientServerInitHandler

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,9 +43,6 @@ func Connect(ctx context.Context, c net.Conn, cfg *ClientConfig) (*ClientConn, e
 		}
 	}
 
-	canvas := NewVncCanvas(int(conn.Width()), int(conn.Height()))
-	canvas.DrawCursor = cfg.DrawCursor
-	conn.Canvas = canvas
 	return conn, nil
 }
 

--- a/example/client/main.go
+++ b/example/client/main.go
@@ -84,15 +84,6 @@ func main() {
 	//go vcodec.Run("C:\\Users\\betzalel\\Dropbox\\go\\src\\vnc2video\\example\\client\\ffmpeg.exe", "output.mp4")
 	//vcodec.Run("./output")
 
-	//screenImage := vnc.NewVncCanvas(int(cc.Width()), int(cc.Height()))
-
-	for _, enc := range ccfg.Encodings {
-		myRenderer, ok := enc.(vnc.Renderer)
-
-		if ok {
-			myRenderer.SetTargetImage(screenImage)
-		}
-	}
 	// var out *os.File
 
 	logger.Tracef("connected to: %s", os.Args[1])

--- a/handlers.go
+++ b/handlers.go
@@ -345,6 +345,21 @@ func (*DefaultClientServerInitHandler) Handle(c Conn) error {
 		//		return err
 		//	}
 	}*/
+
+	// set up canvas and init renderer before other
+	cfg := c.Config().(*ClientConfig)
+	canvas := NewVncCanvas(int(c.Width()), int(c.Height()))
+	canvas.DrawCursor = cfg.DrawCursor
+	c.(*ClientConn).Canvas = canvas
+
+	for _, enc := range cfg.Encodings {
+		myRenderer, ok := enc.(Renderer)
+
+		if ok {
+			myRenderer.SetTargetImage(canvas)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The `nil pointer deference` errors described in #11 and #12 were caused by canvas and renderers not being properly initialized/configured.

1. In `example/client/main.go`, renderers are configured after `ffmpeg` is started.
https://github.com/amitbet/vnc2video/blob/9d50b9dab1d92afd6c71ca5ccc5157135c121428/example/client/main.go#L89-L95
1. But the VNC message handlers are started during the `Connect` call.
https://github.com/amitbet/vnc2video/blob/9d50b9dab1d92afd6c71ca5ccc5157135c121428/example/client/main.go#L60
1. This means that `RemoveCursor`/`PaintCursor` (which requires renderers to be linked with canvas) in `DefaultClientMessageHandler` could be called before the renderers are ready (by `.SetTargetImage(screenImage)` in step 1)
https://github.com/amitbet/vnc2video/blob/9d50b9dab1d92afd6c71ca5ccc5157135c121428/client.go#L302-L306

#12 proposed that `RemoveCursort` should ignore missing canvas, but a more fundamental fix is to perform the renderer configuration in `DefaultClientServerInitHandler` right after the size of the canvas is known.