### PR TITLE
Ensure that ffmpeg is called correctly

### DIFF
--- a/encoders/dv8-enc.go
+++ b/encoders/dv8-enc.go
@@ -26,8 +26,7 @@ func (enc *VP8ImageEncoder) Init(videoFileName string) {
 	if !strings.HasSuffix(videoFileName, fileExt) {
 		videoFileName = videoFileName + fileExt
 	}
-	binary := "./ffmpeg"
-	cmd := exec.Command(binary,
+	cmd := exec.Command(enc.FFMpegBinPath,
 		"-f", "image2pipe",
 		"-vcodec", "ppm",
 		//"-r", strconv.Itoa(framerate),

--- a/encoders/dv8-enc.go
+++ b/encoders/dv8-enc.go
@@ -1,6 +1,7 @@
 package encoders
 
 import (
+	"fmt"
 	"image"
 	"io"
 	"os"
@@ -31,7 +32,7 @@ func (enc *VP8ImageEncoder) Init(videoFileName string) {
 		"-vcodec", "ppm",
 		//"-r", strconv.Itoa(framerate),
 		"-vsync", "2",
-		"-r", "5",
+		"-r", fmt.Sprint(enc.Framerate),
 		"-probesize", "10000000",
 		"-an", //no audio
 		//"-vsync", "2",

--- a/encoders/dv9-enc.go
+++ b/encoders/dv9-enc.go
@@ -25,8 +25,7 @@ func (enc *DV9ImageEncoder) Init(videoFileName string) {
 	if !strings.HasSuffix(videoFileName, fileExt) {
 		videoFileName = videoFileName + fileExt
 	}
-	binary := "./ffmpeg"
-	cmd := exec.Command(binary,
+	cmd := exec.Command(enc.FFMpegBinPath,
 		"-f", "image2pipe",
 		"-vcodec", "ppm",
 		//"-r", strconv.Itoa(framerate),

--- a/encoders/dv9-enc.go
+++ b/encoders/dv9-enc.go
@@ -1,6 +1,7 @@
 package encoders
 
 import (
+	"fmt"
 	"image"
 	"io"
 	"os"
@@ -29,7 +30,7 @@ func (enc *DV9ImageEncoder) Init(videoFileName string) {
 		"-f", "image2pipe",
 		"-vcodec", "ppm",
 		//"-r", strconv.Itoa(framerate),
-		"-r", "5",
+		"-r", fmt.Sprint(enc.Framerate),
 		//"-i", "pipe:0",
 		"-i", "-",
 		"-vcodec", "libvpx-vp9", //"libvpx",//"libvpx-vp9"//"libx264"

--- a/encoders/huffyuv-enc.go
+++ b/encoders/huffyuv-enc.go
@@ -2,6 +2,7 @@ package encoders
 
 import (
 	"errors"
+	"fmt"
 	"image"
 	"io"
 	"os"
@@ -33,7 +34,7 @@ func (enc *HuffYuvImageEncoder) Init(videoFileName string) {
 		"-f", "image2pipe",
 		"-vcodec", "ppm",
 		//"-r", strconv.Itoa(framerate),
-		"-r", "12",
+		"-r", fmt.Sprint(enc.Framerate),
 
 		//"-re",
 		//"-i", "pipe:0",

--- a/encoders/qtrle-enc.go
+++ b/encoders/qtrle-enc.go
@@ -3,6 +3,7 @@ package encoders
 import (
 	"errors"
 	"image"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -32,7 +33,7 @@ func (enc *QTRLEImageEncoder) Init(videoFileName string) {
 		"-f", "image2pipe",
 		"-vcodec", "ppm",
 		//"-r", strconv.Itoa(framerate),
-		"-r", "12",
+		"-r", fmt.Sprint(enc.Framerate),
 
 		//"-re",
 		//"-i", "pipe:0",


### PR DESCRIPTION
This ensures files have correct duration in VLC (and possibly other players).