### PR TITLE
Fix up RGBA transparency values

### DIFF
--- a/rgb-image.go
+++ b/rgb-image.go
@@ -21,7 +21,7 @@ type RGBColor struct {
 }
 
 func (c RGBColor) RGBA() (r, g, b, a uint32) {
-	return uint32(c.R), uint32(c.G), uint32(c.B), 1
+	return uint32(c.R), uint32(c.G), uint32(c.B), 0xff
 }
 
 func (p *RGBImage) ColorModel() color.Model { return nil }
@@ -30,7 +30,7 @@ func (p *RGBImage) Bounds() image.Rectangle { return p.Rect }
 
 func (p *RGBImage) At(x, y int) color.Color {
 	col := p.RGBAt(x, y)
-	return color.RGBA{col.R, col.G, col.B, 1}
+	return color.RGBA{col.R, col.G, col.B, 0xff}
 }
 
 func (p *RGBImage) RGBAt(x, y int) *RGBColor {


### PR DESCRIPTION
This PR updates the RGBA transparency values so pixels are non-transparent.

This fixes an issue where if you would encode to an image format that supported transparency you would just end up with a totally transparent image. 